### PR TITLE
Supply the pipeline default branch to auto selections

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,22 @@ REGION=us-west-1
 A list of environment pre-selections that will be rendered immediately by the plugin
 using the values specified (semi-colon separated).
 
+When a template is rendered as an auto-selection, the value of the standard
+Buildkite variable `BUILDKITE_PIPELINE_DEFAULT_BRANCH` will be copied to an
+environment variable named `AUTO_SELECTION_DEFAULT_BRANCH`. This allows steps
+rendered for auto-selections to use branch filters that work differently. For
+example, a step definition like:
+
+```yaml
+steps:
+  - label: "Deploy to ${STEP_ENVIRONMENT} (${REGION})"
+    command: "bin/ci_deploy"
+    branches: "${AUTO_SELECTION_DEFAULT_BRANCH:-*}"
+```
+
+When output as an auto-selection, it will only run on the default branch. When
+output from a selector, it will run on any branch.
+
 ### `selector-template` (Optional, string)
 
 A template containing the available environment specified as a Buildkite pipeline

--- a/hooks/command
+++ b/hooks/command
@@ -59,5 +59,12 @@ fi
 
 # write auto-selections
 if [[ -n "${auto_selections}" ]]; then
-  write_steps "${step_template}" "${step_var_names}" "${auto_selections}"
+  (
+    # Write the default branch for the pipeline into the environment just for
+    # automatic steps. Allows builds to vary branch selectors on an automatic
+    # build.
+    export AUTO_SELECTION_DEFAULT_BRANCH="${BUILDKITE_PIPELINE_DEFAULT_BRANCH}"
+
+    write_steps "${step_template}" "${step_var_names}" "${auto_selections}"
+  )
 fi

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -6,6 +6,7 @@ load '/usr/local/lib/bats/load.bash'
 # export BUILDKITE_AGENT_STUB_DEBUG=/dev/tty
 
 setup() {
+  export BUILDKITE_PIPELINE_DEFAULT_BRANCH="default-value-from-setup"
   export unstub_path="$PATH"
   export PATH="$BATS_TEST_DIRNAME/fixtures/bin:$PATH"
   [ ! -f "/tmp/step-template.yaml" ] && touch /tmp/step-template.yaml
@@ -45,6 +46,19 @@ teardown() {
   assert_success
   assert_output --partial "stubenv(auto-one): STEP_ENVIRONMENT=auto-one"
   assert_output --partial "stubenv(auto-two): STEP_ENVIRONMENT=auto-two"
+}
+
+@test "Writes additional branch variable for auto selections" {
+  export BUILDKITE_PLUGIN_STEP_TEMPLATES_STEP_TEMPLATE="/tmp/step-template.yaml"
+  export BUILDKITE_PLUGIN_STEP_TEMPLATES_AUTO_SELECTIONS_0="auto-one"
+  export BUILDKITE_PLUGIN_STEP_TEMPLATES_AUTO_SELECTIONS_1="auto-two"
+  export BUILDKITE_PIPELINE_DEFAULT_BRANCH="default-branch"
+
+  run "$PWD/hooks/command"
+
+  assert_success
+  assert_output --partial "stubauto(auto-one): AUTO_SELECTION_DEFAULT_BRANCH=default-branch"
+  assert_output --partial "stubauto(auto-two): AUTO_SELECTION_DEFAULT_BRANCH=default-branch"
 }
 
 @test "Writes steps from meta-data selections" {

--- a/tests/fixtures/bin/buildkite-agent
+++ b/tests/fixtures/bin/buildkite-agent
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# used to stub buildkite-ageent
+# used to stub buildkite-agent
 # the stub library interacts poorly with the read loop present in write_steps
 
 if [[ "${1:-}" == "meta-data" ]]; then
@@ -14,3 +14,4 @@ echo "stubargs($STEP_ENVIRONMENT):$@"
 env | grep STEP_ | xargs -n 1 echo "stubenv($STEP_ENVIRONMENT):"
 env | grep NAMED_ | xargs -n 1 echo "stubnamed($STEP_ENVIRONMENT):"
 env | grep file_ | xargs -n 1 echo "stubfile($STEP_ENVIRONMENT):"
+env | grep AUTO_ | xargs -n 1 echo "stubauto($STEP_ENVIRONMENT):"


### PR DESCRIPTION
Supplying this value allows pipelines that are using automatic selections to use the value of `AUTO_SELECTION_DEFAULT_BRANCH` in branch filters (and other places), allowing them to behave differently as necessary.