### PR TITLE
Allow env files with "`export name=value`" syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,18 @@ TYPE=preprod
 REGION=us-west-1
 ```
 
+**Alternatively:**
+
+It is possible to use `export` style syntax in the env file for more complex use cases.
+
+```shell
+export STEP_ENVIRONMENT="staging"
+export TYPE="preprod"
+export REGION="us-west-1"
+```
+
+The two syntaxes cannot be used in the same file. The presence of a line with the prefix `export \w` will trigger the alternate syntax.
+
 ### `auto-selections` (Optional, string)
 
 A list of environment pre-selections that will be rendered immediately by the plugin

--- a/lib/steps.bash
+++ b/lib/steps.bash
@@ -83,9 +83,15 @@ function load_env_file() {
     return
   fi
 
-  # FIXME this doesn't handle a lot of cases right now, including spaces and multi-line values
-  local vars; vars="$(grep -v '^#' "${env_file}")"
+  if grep -q '^export \w' "${env_file}"; then
+    # contains export statements
+    source "${env_file}"
+  else
+    # This only handles simple cases; values with spaces and multiple lines
+    # should use the `export` syntax.
+    local vars; vars="$(grep -v '^#' "${env_file}")"
 
-  #shellcheck disable=SC2046
-  export $(xargs <<< "${vars}")
+    #shellcheck disable=SC2046
+    export $(xargs <<< "${vars}")
+  fi
 }

--- a/tests/fixtures/env/basic.env
+++ b/tests/fixtures/env/basic.env
@@ -1,3 +1,4 @@
 one=first
 two=second
+# comments are allowed
 three=third

--- a/tests/fixtures/env/spaces.env
+++ b/tests/fixtures/env/spaces.env
@@ -1,0 +1,6 @@
+export onespace="first one"
+export twospace="second two"
+export threespace="third three"
+# comments are allowed
+export simple=value
+

--- a/tests/steps_util.bats
+++ b/tests/steps_util.bats
@@ -27,3 +27,11 @@ load '../lib/steps'
     assert_equal "${two}" "second"
     assert_equal "${three}" "third"
 }
+
+@test "load_env_file loads file with spaces in values into environment" {
+    load_env_file "./tests/fixtures/env/spaces.env"
+
+    assert_equal "${onespace}" "first one"
+    assert_equal "${twospace}" "second two"
+    assert_equal "${threespace}" "third three"
+}


### PR DESCRIPTION
This adds the option for `.env` files (loaded for a step environment) to use the common `export name="value"` syntax. This opens the door for including other files, and values with spaces.

This might be a useful alternative to #2, as stable, maintainable text parsing in shell is something of a Sisyphean endeavour.
