### PR TITLE
feat: add `STEP_ID` to the generated step templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ AGENT=staging_agent_pool_name
 This is an easy way of adding additional variables per environment without
 making the selector definitions very long and hard to read.
 
+Additionally, the `STEP_ID` variable provides a unique identifier for each step triggered by the plugin. It can be used to establish step dependencies via `depends_on` or to generate unique keys for steps, such as `deploy-${STEP_ENVIRONMENT}-${STEP_ID}`. This facilitates better coordination and tracking of related steps within the pipeline.
+
 ## How it works
 
 The block step (from the `deploy-selector.yaml`) has a [`select`
@@ -166,6 +168,8 @@ This will be something like:
 development-us;flamingo;us-west-2
 staging-us;preprod;us-west-2
 ```
+
+For each selected environment, the `STEP_ID` variable will also be set to the value of `BUILDKITE_JOB_ID` (if available), allowing steps to reference the unique job ID.
 
 The `deploy-selector.yaml` has _another_ step that executes the plugin, running
 after a selection occurs. The plugin reads the meta-data key and iterates over

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ AGENT=staging_agent_pool_name
 This is an easy way of adding additional variables per environment without
 making the selector definitions very long and hard to read.
 
-Additionally, the `STEP_ID` variable provides a unique identifier for each step triggered by the plugin. It can be used to establish step dependencies via `depends_on` or to generate unique keys for steps, such as `deploy-${STEP_ENVIRONMENT}-${STEP_ID}`. This facilitates better coordination and tracking of related steps within the pipeline.
+Additionally, the `STEP_SELECTOR_ID` variable provides a unique identifier for each step triggered by the plugin. It can be used to establish step dependencies via `depends_on` or to generate unique keys for steps, such as `deploy-${STEP_ENVIRONMENT}-${STEP_SELECTOR_ID}`. This facilitates better coordination and tracking of related steps within the pipeline.
 
 ## How it works
 
@@ -169,7 +169,7 @@ development-us;flamingo;us-west-2
 staging-us;preprod;us-west-2
 ```
 
-For each selected environment, the `STEP_ID` variable will also be set to the value of `BUILDKITE_JOB_ID` (if available), allowing steps to reference the unique job ID.
+For each selected environment, the `STEP_SELECTOR_ID` variable will also be set to the value of `BUILDKITE_JOB_ID` (if available), allowing steps to reference the unique job ID.
 
 The `deploy-selector.yaml` has _another_ step that executes the plugin, running
 after a selection occurs. The plugin reads the meta-data key and iterates over

--- a/hooks/command
+++ b/hooks/command
@@ -19,6 +19,11 @@ if [[ -z "${step_template}" ]] ; then
   exit 1
 fi
 
+if [[ -z "${BUILDKITE_JOB_ID}" ]] ; then
+  1>&2 echo "+++ ⚠️ Step templates plugin warning"
+  1>&2 echo "No 'BUILDKITE_JOB_ID' environment variable found: STEP_ID will be empty."
+fi
+
 if [[ -z "${selector_template}" ]]  && [[ -z "${auto_selections}" ]] ; then
   1>&2 echo "+++ ❌ Step templates plugin error"
   1>&2 echo "Neither selector-template nor auto-selections specified: nothing to do."
@@ -52,7 +57,7 @@ if [[ -n "${key}" ]]; then
   echo "Finding selected environments in metadata for key '${key}'"
   selected_environments="$(buildkite-agent meta-data get "${key}" --default "")"
   if [[ -n "${selected_environments}" ]]; then
-    write_steps "${step_template}" "${step_var_names}" "${selected_environments}"
+    write_steps "${step_template}" "${step_var_names}" "${selected_environments}" "${BUILDKITE_JOB_ID:-}"
   fi
 fi
 
@@ -64,6 +69,6 @@ if [[ -n "${auto_selections}" ]]; then
     # build.
     export AUTO_SELECTION_DEFAULT_BRANCH="${BUILDKITE_PIPELINE_DEFAULT_BRANCH}"
 
-    write_steps "${step_template}" "${step_var_names}" "${auto_selections}"
+    write_steps "${step_template}" "${step_var_names}" "${auto_selections}" "${BUILDKITE_JOB_ID:-}"
   )
 fi

--- a/hooks/command
+++ b/hooks/command
@@ -19,7 +19,7 @@ if [[ -z "${step_template}" ]] ; then
   exit 1
 fi
 
-if [[ -z "${BUILDKITE_JOB_ID}" ]] ; then
+if [[ -z "${BUILDKITE_JOB_ID:-}" ]] ; then
   1>&2 echo "+++ ⚠️ Step templates plugin warning"
   1>&2 echo "No 'BUILDKITE_JOB_ID' environment variable found: STEP_ID will be empty."
 fi

--- a/hooks/command
+++ b/hooks/command
@@ -21,7 +21,7 @@ fi
 
 if [[ -z "${BUILDKITE_JOB_ID:-}" ]] ; then
   1>&2 echo "+++ ⚠️ Step templates plugin warning"
-  1>&2 echo "No 'BUILDKITE_JOB_ID' environment variable found: STEP_ID will be empty."
+  1>&2 echo "No 'BUILDKITE_JOB_ID' environment variable found: STEP_SELECTOR_ID will be empty."
 fi
 
 if [[ -z "${selector_template}" ]]  && [[ -z "${auto_selections}" ]] ; then

--- a/lib/steps.bash
+++ b/lib/steps.bash
@@ -34,12 +34,12 @@ function write_steps() {
           msg+=" for environment \"${step_env}\""
         fi
         export STEP_ENVIRONMENT="${step_env}"
-        export STEP_ID="${step_id}"
+        export STEP_SELECTOR_ID="${step_id}"
 
         echo "${msg}"
         echo "Environment setup:"
         echo "STEP_ENVIRONMENT=\"${STEP_ENVIRONMENT}\""
-        echo "STEP_ID=\"${STEP_ID}\""
+        echo "STEP_SELECTOR_ID=\"${STEP_SELECTOR_ID}\""
 
         # output > 1 as named in step-var-names, making up a default if needed
         for ((i=1; i < ${#step_vars[@]}; ++i)); do

--- a/lib/steps.bash
+++ b/lib/steps.bash
@@ -6,6 +6,7 @@ function write_steps() {
   local template="${1}"
   local raw_var_names="${2}"
   local selected_environments="${3}"
+  local step_id="${4}"
 
   # this is passed as a newline-delimited string, as passing arrays is ... not really a thing
   local var_names; readarray -t var_names <<< "${raw_var_names}"
@@ -33,10 +34,12 @@ function write_steps() {
           msg+=" for environment \"${step_env}\""
         fi
         export STEP_ENVIRONMENT="${step_env}"
+        export STEP_ID="${step_id}"
 
         echo "${msg}"
         echo "Environment setup:"
         echo "STEP_ENVIRONMENT=\"${STEP_ENVIRONMENT}\""
+        echo "STEP_ID=\"${STEP_ID}\""
 
         # output > 1 as named in step-var-names, making up a default if needed
         for ((i=1; i < ${#step_vars[@]}; ++i)); do

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -74,3 +74,25 @@ teardown() {
   assert_output --partial "stubenv(select-one): STEP_ENVIRONMENT=select-one"
   assert_output --partial "stubenv(select-two): STEP_ENVIRONMENT=select-two"
 }
+
+@test "STEP_ID is set when BUILDKITE_JOB_ID is provided" {
+  export BUILDKITE_PLUGIN_STEP_TEMPLATES_STEP_TEMPLATE="/tmp/step-template.yaml"
+  export BUILDKITE_PLUGIN_STEP_TEMPLATES_SELECTOR_TEMPLATE="/tmp/selector-template.yaml"
+  export BUILDKITE_JOB_ID="test-job-id"
+
+  run "$PWD/hooks/command"
+
+  assert_success
+  assert_output --partial "STEP_ID=\"test-job-id\""
+}
+
+@test "STEP_ID is empty when BUILDKITE_JOB_ID is not provided" {
+  export BUILDKITE_PLUGIN_STEP_TEMPLATES_STEP_TEMPLATE="/tmp/step-template.yaml"
+  export BUILDKITE_PLUGIN_STEP_TEMPLATES_SELECTOR_TEMPLATE="/tmp/selector-template.yaml"
+  unset BUILDKITE_JOB_ID
+
+  run "$PWD/hooks/command"
+
+  assert_success
+  assert_output --partial "STEP_ID=\"\""
+}

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -7,6 +7,7 @@ load "$BATS_PLUGIN_PATH/load.bash"
 
 setup() {
   export BUILDKITE_PIPELINE_DEFAULT_BRANCH="default-value-from-setup"
+  export BUILDKITE_JOB_ID="7b35feca-d1b9-423a-9cad-4107b6b40dd9"
   export unstub_path="$PATH"
   export PATH="$BATS_TEST_DIRNAME/fixtures/bin:$PATH"
   [ ! -f "/tmp/step-template.yaml" ] && touch /tmp/step-template.yaml

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -75,7 +75,7 @@ teardown() {
   assert_output --partial "stubenv(select-two): STEP_ENVIRONMENT=select-two"
 }
 
-@test "STEP_ID is set when BUILDKITE_JOB_ID is provided" {
+@test "STEP_SELECTOR_ID is set when BUILDKITE_JOB_ID is provided" {
   export BUILDKITE_PLUGIN_STEP_TEMPLATES_STEP_TEMPLATE="/tmp/step-template.yaml"
   export BUILDKITE_PLUGIN_STEP_TEMPLATES_SELECTOR_TEMPLATE="/tmp/selector-template.yaml"
   export BUILDKITE_JOB_ID="test-job-id"
@@ -83,10 +83,10 @@ teardown() {
   run "$PWD/hooks/command"
 
   assert_success
-  assert_output --partial "STEP_ID=\"test-job-id\""
+  assert_output --partial "STEP_SELECTOR_ID=\"test-job-id\""
 }
 
-@test "STEP_ID is empty when BUILDKITE_JOB_ID is not provided" {
+@test "STEP_SELECTOR_ID is empty when BUILDKITE_JOB_ID is not provided" {
   export BUILDKITE_PLUGIN_STEP_TEMPLATES_STEP_TEMPLATE="/tmp/step-template.yaml"
   export BUILDKITE_PLUGIN_STEP_TEMPLATES_SELECTOR_TEMPLATE="/tmp/selector-template.yaml"
   unset BUILDKITE_JOB_ID
@@ -94,5 +94,5 @@ teardown() {
   run "$PWD/hooks/command"
 
   assert_success
-  assert_output --partial "STEP_ID=\"\""
+  assert_output --partial "STEP_SELECTOR_ID=\"\""
 }

--- a/tests/steps_write.bats
+++ b/tests/steps_write.bats
@@ -11,6 +11,7 @@ export BUILDKITE_AGENT_STUB_DEBUG=/dev/tty
 setup() {
   export unstub_path="$PATH"
   export PATH="$BATS_TEST_DIRNAME/fixtures/bin:$PATH"
+  export BUILDKITE_JOB_ID="7b35feca-d1b9-423a-9cad-4107b6b40dd9"
 
   mkdir /tmp/steps 2>&1 | true
   cat > /tmp/steps/c.env <<<'
@@ -26,7 +27,7 @@ teardown() {
 @test "write_steps runs template for each env" {
   local template="/tmp/steps/template.yaml"
 
-  run write_steps "$template" "" $'a\nb\nc'
+  run write_steps "$template" "" $'a\nb\nc' "$BUILDKITE_JOB_ID"
   assert_success
 
   assert_output --partial "stubargs(a):pipeline upload /tmp/steps/template.yaml"
@@ -37,7 +38,7 @@ teardown() {
 @test "write_steps creates arguments with default names for each env" {
   local template="/tmp/steps/template.yaml"
 
-  run write_steps "$template" "" $'a;aa\nb\nc;c1;c2;c3'
+  run write_steps "$template" "" $'a;aa\nb\nc;c1;c2;c3' "$BUILDKITE_JOB_ID"
   assert_success
 
   assert_output --partial "stubenv(a): STEP_VAR_1=aa"
@@ -50,7 +51,7 @@ teardown() {
 @test "write_steps creates arguments with specified names" {
   local template="/tmp/steps/template.yaml"
 
-  run write_steps "$template" $'named_1\nnamed_2' $'a;aa\nb\nc;c1;c2;c3'
+  run write_steps "$template" $'named_1\nnamed_2' $'a;aa\nb\nc;c1;c2;c3' "$BUILDKITE_JOB_ID"
   assert_success
 
   # named vars should exist where names supplied


### PR DESCRIPTION
## Purpose

This pull request introduces the `STEP_SELECTOR_ID` variable to improve step identification and dependency management in Buildkite pipelines. Key updates include:

- Passing `BUILDKITE_JOB_ID` as `STEP_SELECTOR_ID` in and adding a warning if it's not set.
- Enhancing the `write_steps` function to handle and export the `STEP_SELECTOR_ID` variable.
- Adding tests to validate `STEP_SELECTOR_ID` behavior and ensure compatibility with existing functionality.

## Question 

The goal of this change was to introduce built-in functionality similar to the combination of [TRIGGER_JOB_ID](https://github.com/cultureamp/kafka-ops/blob/ccd5d69402f947ba8a5c6a6fe008580b58877ade/.buildkite/deploy/_infrastructure-steps.yaml#L35-L36) and [BUILDKITE_JOB_ID](https://github.com/cultureamp/kafka-ops/blob/ccd5d69402f947ba8a5c6a6fe008580b58877ade/.buildkite/infrastructure.yaml#L1-L12). While other approaches could achieve similar results, I followed the existing logic of using `BUILDKITE_JOB_ID` as the identifier for downstream actions.

### Feedback Requested

I’m looking for feedback on the following:
- The name `STEP_ID`: Does it clearly convey its purpose?
- The source of the `UUID`: Is `BUILDKITE_JOB_ID` the best choice, or should another source be considered?
- Handling the absence of the value: Currently, a warning is logged, and `STEP_ID` is set to an empty string (`""`). Is this approach sufficient, or should it be handled differently?