### PR TITLE
fix: various fixes

### DIFF
--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,1 @@
+external-sources=true

--- a/hooks/command
+++ b/hooks/command
@@ -50,7 +50,6 @@ fi
 
 if [[ -n "${key}" ]]; then
   echo "Finding selected environments in metadata for key '${key}'"
-  buildkite-agent meta-data get "${key}" --default ""
   selected_environments="$(buildkite-agent meta-data get "${key}" --default "")"
   if [[ -n "${selected_environments}" ]]; then
     write_steps "${step_template}" "${step_var_names}" "${selected_environments}"

--- a/hooks/command
+++ b/hooks/command
@@ -33,7 +33,7 @@ if [[ ! -f "${step_template}" ]]; then
 fi
 
 
-# template fragements are written in reverse order: each fragment will be rendered immediately
+# template fragments are written in reverse order: each fragment will be rendered immediately
 # after the currently executing step.
 
 # upload the selection steps template to the pipeline

--- a/hooks/command
+++ b/hooks/command
@@ -3,9 +3,9 @@ set -ueo pipefail
 
 DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 
-# shellcheck source=lib/shared.bash
+# shellcheck source=../lib/shared.bash
 . "$DIR/../lib/shared.bash"
-# shellcheck source=lib/steps.bash
+# shellcheck source=../lib/steps.bash
 . "$DIR/../lib/steps.bash"
 
 step_template="$(plugin_read_config "STEP_TEMPLATE")"

--- a/lib/steps.bash
+++ b/lib/steps.bash
@@ -85,6 +85,7 @@ function load_env_file() {
 
   if grep -q '^export \w' "${env_file}"; then
     # contains export statements
+    # shellcheck disable=SC1090
     source "${env_file}"
   else
     # This only handles simple cases; values with spaces and multiple lines


### PR DESCRIPTION
## Purpose

This pull request improves shell script configurations, fixes file references, and enhances code readability:

- Enabled external-sources in `.shellcheckrc` to follow external file references.
- Corrected `shellcheck` file paths for shared.bash and `steps.bash` in command.
- Fixed a typo ("fragements" → "fragments") and simplified metadata retrieval logic in command.
- Added a `shellcheck` directive in `steps.bash` to handle dynamic sourcing of environment files.