### PR TITLE
refactor: key extraction and enhance documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,10 +258,32 @@ A template containing the available environment specified as a Buildkite pipelin
 `block` step that supplies a set of `fields` for selection. The selection may be
 optional.
 
-> **Note:** The value for `key:` has to be unique per pipeline, as it is used as
-the name of the metadata key that the selections are read from. If you use have
-a pipeline with multiple block steps that have options, each of them has to be
-assigned a different value.
+#### The `block` `key` value
+
+> [!WARNING]
+> Each `block` step must use a unique `key` within the pipeline. If two or more `block` steps share the same `key`, their selections will overwrite each other in the Buildkite metadata, resulting in unexpected behaviour.
+
+The `key` field in a `block` step is essential—it defines the metadata key where Buildkite stores the user's selection. This key allows the plugin to later retrieve the selected values using Buildkite’s metadata commands.
+
+For example, consider the following `block` step:
+
+```yaml
+steps:
+  - block: Deploy to?
+    fields:
+      - select: Environment
+        key: deploy-restricted
+        multiple: true
+        required: true
+        options:
+          - label: Dev
+            value: development
+          - label: Prod
+            value: production
+```
+
+- The `key: deploy-restricted` indicates that the selected environment values will be stored in Buildkite’s metadata under the key `deploy-restricted`.
+- The plugin retrieves this value using `buildkite-agent meta-data get deploy-restricted` to determine which environments the user selected.
 
 ## Developing
 

--- a/README.md
+++ b/README.md
@@ -261,11 +261,13 @@ optional.
 #### The `block` `key` value
 
 > [!WARNING]
-> Each `block` step must use a unique `key` within the pipeline. If two or more `block` steps share the same `key`, their selections will overwrite each other in the Buildkite metadata, resulting in unexpected behaviour.
+> Each `block` step must use a unique `key` within the pipeline. If two or more `block` steps share the same `key`, their selections will overwrite each other in the Buildkite metadata, leading to unexpected behaviour.
 
-The `key` field in a `block` step is essential—it defines the metadata key where Buildkite stores the user's selection. This key allows the plugin to later retrieve the selected values using Buildkite’s metadata commands.
+The short version: we use the value of the first `key` field found in the `selector-template` file.
 
-For example, consider the following `block` step:
+This `key` is critical—it defines the metadata entry where Buildkite stores the user’s selection. The plugin then uses this metadata to determine what was selected, typically via `buildkite-agent meta-data get`.
+
+For example, in the following `block` step:
 
 ```yaml
 steps:

--- a/hooks/command
+++ b/hooks/command
@@ -45,7 +45,7 @@ fi
 # write items selected and held in metadata
 key=""
 if [[ -z "$key" && -f "${selector_template}" ]]; then
-  key="$(grep -P -o "(?<=key: )[\w-]+" "${selector_template}" | head -n1 || true)"
+  key="$(extract_key_from_template "${selector_template}")"
 fi
 
 if [[ -n "${key}" ]]; then

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -31,3 +31,28 @@ function prefix_read_list() {
     echo "${!prefix}"
   fi
 }
+
+# Extract the first occurrence of a "key" field from a YAML template file.
+#
+# Arguments:
+#   $1 - The path to the YAML template file.
+#
+# Behaviour:
+#   - Searches for lines in the file that match the pattern "key: <value>".
+#   - Extracts the value of the first "key" field found.
+#   - If no "key" field is found, returns an empty string.
+#
+# Example:
+#   Given a file with the content:
+#     key: example-key
+#     key: another-key
+#   Running:
+#     extract_key_from_template "template.yaml"
+#   Will return:
+#     example-key
+#
+#   If the file does not contain a "key" field or does not exist, it will return an empty string.
+function extract_key_from_template() {
+  local template="$1"
+  grep -P -o "(?<=key: )[\w-]+" "${template}" | head -n1 || true
+}

--- a/tests/shared.bats
+++ b/tests/shared.bats
@@ -8,12 +8,11 @@ load '../lib/shared'
 
 setup() {
   export BUILDKITE_PIPELINE_DEFAULT_BRANCH="default-value-from-setup"
-  TEMPLATE_PATH=/tmp/templates
-  mkdir -p $TEMPLATE_PATH
+  TEMPLATE_DIR=$(mktemp -d)
 }
 
 teardown() {
-  rm -rf $TEMPLATE_PATH
+  rm -rf $TEMPLATE_DIR
 }
 
 function create_template_file() {
@@ -24,35 +23,35 @@ function create_template_file() {
 }
 
 @test "extract_key_from_template extracts key from valid template" {
-  create_template_file "$TEMPLATE_PATH/valid_template.yaml" "key: example-key"
-  key="$(extract_key_from_template "$TEMPLATE_PATH/valid_template.yaml")"
+  create_template_file "$TEMPLATE_DIR/valid_template.yaml" "key: example-key"
+  key="$(extract_key_from_template "$TEMPLATE_DIR/valid_template.yaml")"
 
   assert_equal "${key}" "example-key"
 }
 
 @test "extract_key_from_template returns empty string for template without key" {
-  create_template_file "$TEMPLATE_PATH/no_key_template.yaml" "name: example-name"
-  key="$(extract_key_from_template "$TEMPLATE_PATH/no_key_template.yaml")"
+  create_template_file "$TEMPLATE_DIR/no_key_template.yaml" "name: example-name"
+  key="$(extract_key_from_template "$TEMPLATE_DIR/no_key_template.yaml")"
 
   assert_equal "${key}" ""
 }
 
 @test "extract_key_from_template handles missing file gracefully" {
-  key="$(extract_key_from_template "$TEMPLATE_PATH/missing_template.yaml")"
+  key="$(extract_key_from_template "$TEMPLATE_DIR/missing_template.yaml")"
 
   assert_equal "${key}" ""
 }
 
 @test "extract_key_from_template extracts the first key when multiple keys have the same value" {
-  create_template_file "$TEMPLATE_PATH/same_keys_template.yaml" "key: example-key\nkey: example-key"
-  key="$(extract_key_from_template "$TEMPLATE_PATH/same_keys_template.yaml")"
+  create_template_file "$TEMPLATE_DIR/same_keys_template.yaml" "key: example-key\nkey: example-key"
+  key="$(extract_key_from_template "$TEMPLATE_DIR/same_keys_template.yaml")"
 
   assert_equal "${key}" "example-key"
 }
 
 @test "extract_key_from_template extracts the first key when multiple keys have different values" {
-  create_template_file "$TEMPLATE_PATH/different_keys_template.yaml" "key: first-key\nkey: second-key"
-  key="$(extract_key_from_template "$TEMPLATE_PATH/different_keys_template.yaml")"
+  create_template_file "$TEMPLATE_DIR/different_keys_template.yaml" "key: first-key\nkey: second-key"
+  key="$(extract_key_from_template "$TEMPLATE_DIR/different_keys_template.yaml")"
 
   assert_equal "${key}" "first-key"
 }

--- a/tests/shared.bats
+++ b/tests/shared.bats
@@ -1,0 +1,58 @@
+#!/usr/bin/env bats
+
+load "$BATS_PLUGIN_PATH/load.bash"
+load '../lib/shared'
+
+# Uncomment the following line to debug stub failures
+# export BUILDKITE_AGENT_STUB_DEBUG=/dev/tty
+
+setup() {
+  export BUILDKITE_PIPELINE_DEFAULT_BRANCH="default-value-from-setup"
+  TEMPLATE_PATH=/tmp/templates
+  mkdir -p $TEMPLATE_PATH
+}
+
+teardown() {
+  rm -rf $TEMPLATE_PATH
+}
+
+function create_template_file() {
+  local path="$1"
+  local content="$2"
+  mkdir -p "$(dirname "${path}")"
+  echo "${content}" >"${path}"
+}
+
+@test "extract_key_from_template extracts key from valid template" {
+  create_template_file "$TEMPLATE_PATH/valid_template.yaml" "key: example-key"
+  key="$(extract_key_from_template "$TEMPLATE_PATH/valid_template.yaml")"
+
+  assert_equal "${key}" "example-key"
+}
+
+@test "extract_key_from_template returns empty string for template without key" {
+  create_template_file "$TEMPLATE_PATH/no_key_template.yaml" "name: example-name"
+  key="$(extract_key_from_template "$TEMPLATE_PATH/no_key_template.yaml")"
+
+  assert_equal "${key}" ""
+}
+
+@test "extract_key_from_template handles missing file gracefully" {
+  key="$(extract_key_from_template "$TEMPLATE_PATH/missing_template.yaml")"
+
+  assert_equal "${key}" ""
+}
+
+@test "extract_key_from_template extracts the first key when multiple keys have the same value" {
+  create_template_file "$TEMPLATE_PATH/same_keys_template.yaml" "key: example-key\nkey: example-key"
+  key="$(extract_key_from_template "$TEMPLATE_PATH/same_keys_template.yaml")"
+
+  assert_equal "${key}" "example-key"
+}
+
+@test "extract_key_from_template extracts the first key when multiple keys have different values" {
+  create_template_file "$TEMPLATE_PATH/different_keys_template.yaml" "key: first-key\nkey: second-key"
+  key="$(extract_key_from_template "$TEMPLATE_PATH/different_keys_template.yaml")"
+
+  assert_equal "${key}" "first-key"
+}


### PR DESCRIPTION
## Purpose 

Move key extraction logic to a dedicated function and add comprehensive test coverage. Update the README to clarify the requirement for unique keys in block steps to prevent metadata conflicts.


## Context

The current documentation make it quite easy to misunderstand how the `key` field works (I thought it HAD to be `deploy-environment`).