### PR TITLE
feat: add require-up-to-date validation for commit freshness

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,59 @@ A template containing the available environment specified as a Buildkite pipelin
 `block` step that supplies a set of `fields` for selection. The selection may be
 optional.
 
+### `require-up-to-date` (Optional, object)
+
+Validates that the current commit meets _freshness_ requirements before proceeding with step generation. This prevents deployments from stale or outdated commits.
+
+**Why is this useful?**
+
+Without validation, deployments might run from commits that are missing critical changes from the main branch. This is particularly dangerous for IAC like Terraform where missing resource definitions or configuration changes could lead to accidental deletion of infrastructure.
+
+**Common scenarios this prevents:**
+
+1. You're on a feature branch that was created days ago but hasn't been updated with recent main branch changes
+2. You've checked out an old commit locally and forgotten to pull the latest changes
+3. You're deploying from a commit that predates critical infrastructure or security updates
+
+**Properties:**
+
+- `enabled` (boolean, default: `false`) - Whether to enable commit validation
+- `branch` (string, default: `"main"`) - The upstream branch to validate against (ensures current commit includes all changes from `origin/<branch>`)
+- `must-be-branch-head` (boolean, default: `false`) - Require that you're at the head of your current branch (not behind any commits). Note: this check is automatically skipped if you're already on the upstream branch, since that would be redundant.
+
+**Basic Example:**
+
+```yaml
+steps:
+  - plugins:
+      - cultureamp/step-templates#v1.3.0:
+          step-template: deploy-steps.yml
+          require-up-to-date:
+            enabled: true
+            branch: "main"  # or "master", "develop", etc.
+```
+
+**Advanced Example (with must-be-branch-head check):**
+
+```yaml
+steps:
+  - plugins:
+      - cultureamp/step-templates#v1.3.0:
+          step-template: terraform-deploy-steps.yml
+          require-up-to-date:
+            enabled: true
+            branch: "main"
+            must-be-branch-head: true
+```
+
+When enabled, the plugin will:
+
+1. Fetch the latest changes from the specified upstream branch
+2. Check if the current commit includes all changes from `origin/<branch>` (using `git merge-base --is-ancestor`)
+3. If `must-be-branch-head: true`, also verify the current commit is the latest commit on the current branch
+4. Fail with a clear error message if any validation fails
+5. Proceed normally if all validations pass
+
 #### The `block` `key` value
 
 > [!WARNING]

--- a/README.md
+++ b/README.md
@@ -281,6 +281,9 @@ Without validation, deployments might run from commits that are missing critical
 - `enabled` (boolean, default: `false`) - Whether to enable commit validation
 - `branch` (string, default: `"main"`) - The upstream branch to validate against (ensures current commit includes all changes from `origin/<branch>`)
 - `must-be-branch-head` (boolean, default: `false`) - Require that you're at the head of your current branch (not behind any commits). Note: this check is automatically skipped if you're already on the upstream branch, since that would be redundant.
+- `fail-mode` (string, default: `"hard"`) - How to handle validation failures:
+  - `"hard"`: Exit with error code 1 (fails the build)
+  - `"soft"`: Exit with code 0 but skip uploading pipeline steps
 
 **Basic Example:**
 
@@ -305,6 +308,7 @@ steps:
             enabled: true
             branch: "main"
             must-be-branch-head: true
+            fail-mode: "soft"
 ```
 
 When enabled, the plugin will:

--- a/README.md
+++ b/README.md
@@ -281,9 +281,7 @@ Without validation, deployments might run from commits that are missing critical
 - `enabled` (boolean, default: `false`) - Whether to enable commit validation
 - `branch` (string, default: `"main"`) - The upstream branch to validate against (ensures current commit includes all changes from `origin/<branch>`)
 - `must-be-branch-head` (boolean, default: `false`) - Require that you're at the head of your current branch (not behind any commits). Note: this check is automatically skipped if you're already on the upstream branch, since that would be redundant.
-- `fail-mode` (string, default: `"hard"`) - How to handle validation failures:
-  - `"hard"`: Exit with error code 1 (fails the build)
-  - `"soft"`: Exit with code 0 but skip uploading pipeline steps
+- `soft-fail` (boolean, default: `false`) - Allow validation failures without failing the build. When `true`, validation failures will skip uploading steps but won't fail the build.
 
 **Basic Example:**
 
@@ -297,7 +295,7 @@ steps:
             branch: "main"  # or "master", "develop", etc.
 ```
 
-**Advanced Example (with must-be-branch-head check):**
+**Advanced Example (with must-be-branch-head check & soft failures):**
 
 ```yaml
 steps:
@@ -308,7 +306,7 @@ steps:
             enabled: true
             branch: "main"
             must-be-branch-head: true
-            fail-mode: "soft"
+            soft-fail: true  # Won't fail build, just skips steps
 ```
 
 When enabled, the plugin will:

--- a/hooks/command
+++ b/hooks/command
@@ -15,6 +15,7 @@ auto_selections="$(plugin_read_list "AUTO_SELECTIONS")"
 require_up_to_date_enabled="$(plugin_read_config "REQUIRE_UP_TO_DATE_ENABLED" "false")"
 require_up_to_date_branch="$(plugin_read_config "REQUIRE_UP_TO_DATE_BRANCH" "main")"
 require_up_to_date_must_be_branch_head="$(plugin_read_config "REQUIRE_UP_TO_DATE_MUST_BE_BRANCH_HEAD" "false")"
+require_up_to_date_fail_mode="$(plugin_read_config "REQUIRE_UP_TO_DATE_FAIL_MODE" "hard")"
 
 if [[ -z "${step_template}" ]] ; then
   1>&2 echo "+++ ❌ Step templates plugin error"
@@ -43,9 +44,15 @@ fi
 # validate branch is up-to-date if required
 if [[ "${require_up_to_date_enabled}" == "true" ]]; then
   if ! validate_branch_up_to_date "${require_up_to_date_branch}" "${require_up_to_date_must_be_branch_head}"; then
-    1>&2 echo "+++ ❌ Step templates plugin error"
-    1>&2 echo "Branch validation failed: branch requirements not met"
-    exit 1
+    if [[ "${require_up_to_date_fail_mode}" == "soft" ]]; then
+      1>&2 echo "+++ ⚠️ Step templates plugin warning"
+      1>&2 echo "Branch validation failed: branch requirements not met (soft-fail mode: continuing without uploading steps)"
+      exit 0
+    else
+      1>&2 echo "+++ ❌ Step templates plugin error"
+      1>&2 echo "Branch validation failed: branch requirements not met"
+      exit 1
+    fi
   fi
 fi
 

--- a/hooks/command
+++ b/hooks/command
@@ -12,6 +12,9 @@ step_template="$(plugin_read_config "STEP_TEMPLATE")"
 selector_template="$(plugin_read_config "SELECTOR_TEMPLATE")"
 step_var_names="$(plugin_read_list "STEP_VAR_NAMES")"
 auto_selections="$(plugin_read_list "AUTO_SELECTIONS")"
+require_up_to_date_enabled="$(plugin_read_config "REQUIRE_UP_TO_DATE_ENABLED" "false")"
+require_up_to_date_branch="$(plugin_read_config "REQUIRE_UP_TO_DATE_BRANCH" "main")"
+require_up_to_date_must_be_branch_head="$(plugin_read_config "REQUIRE_UP_TO_DATE_MUST_BE_BRANCH_HEAD" "false")"
 
 if [[ -z "${step_template}" ]] ; then
   1>&2 echo "+++ ❌ Step templates plugin error"
@@ -35,6 +38,15 @@ if [[ ! -f "${step_template}" ]]; then
   1>&2 echo "+++ ❌ Step templates plugin error"
   1>&2 echo "Specified step template does not exist: '${step_template}'"
   exit 1
+fi
+
+# validate branch is up-to-date if required
+if [[ "${require_up_to_date_enabled}" == "true" ]]; then
+  if ! validate_branch_up_to_date "${require_up_to_date_branch}" "${require_up_to_date_must_be_branch_head}"; then
+    1>&2 echo "+++ ❌ Step templates plugin error"
+    1>&2 echo "Branch validation failed: branch requirements not met"
+    exit 1
+  fi
 fi
 
 

--- a/hooks/command
+++ b/hooks/command
@@ -15,7 +15,7 @@ auto_selections="$(plugin_read_list "AUTO_SELECTIONS")"
 require_up_to_date_enabled="$(plugin_read_config "REQUIRE_UP_TO_DATE_ENABLED" "false")"
 require_up_to_date_branch="$(plugin_read_config "REQUIRE_UP_TO_DATE_BRANCH" "main")"
 require_up_to_date_must_be_branch_head="$(plugin_read_config "REQUIRE_UP_TO_DATE_MUST_BE_BRANCH_HEAD" "false")"
-require_up_to_date_fail_mode="$(plugin_read_config "REQUIRE_UP_TO_DATE_FAIL_MODE" "hard")"
+require_up_to_date_soft_fail="$(plugin_read_config "REQUIRE_UP_TO_DATE_SOFT_FAIL" "false")"
 
 if [[ -z "${step_template}" ]] ; then
   1>&2 echo "+++ ❌ Step templates plugin error"
@@ -44,7 +44,7 @@ fi
 # validate branch is up-to-date if required
 if [[ "${require_up_to_date_enabled}" == "true" ]]; then
   if ! validate_branch_up_to_date "${require_up_to_date_branch}" "${require_up_to_date_must_be_branch_head}"; then
-    if [[ "${require_up_to_date_fail_mode}" == "soft" ]]; then
+    if [[ "${require_up_to_date_soft_fail}" == "true" ]]; then
       1>&2 echo "+++ ⚠️ Step templates plugin warning"
       1>&2 echo "Branch validation failed: branch requirements not met (soft-fail mode: continuing without uploading steps)"
       exit 0

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -56,3 +56,75 @@ function extract_key_from_template() {
   local template="$1"
   grep -P -o "(?<=key: )[\w-]+" "${template}" | head -n1 || true
 }
+
+# Validates that the current commit meets freshness requirements
+#
+# Arguments:
+#   $1 - The upstream branch to check against (e.g., "main", "master")
+#   $2 - Whether to also check current commit is at branch head (true/false, default: false)
+#
+# Returns:
+#   0 if commit meets all requirements
+#   1 if commit is stale or validation fails
+function validate_branch_up_to_date() {
+  local upstream_branch="${1:-main}"
+  local check_current_branch_head="${2:-false}"
+  local origin_branch="origin/${upstream_branch}"
+
+  echo "--- Checking if current commit includes all changes from ${origin_branch}"
+
+  # Fetch latest changes from origin
+  if ! git fetch origin "${upstream_branch}" 2>/dev/null; then
+    echo "❌ Failed to fetch from ${origin_branch}"
+    echo "Make sure the branch '${upstream_branch}' exists on origin"
+    return 1
+  fi
+
+  # Check if current HEAD includes all changes from origin branch
+  if git merge-base --is-ancestor HEAD "${origin_branch}"; then
+    echo "✅ Current commit includes all changes from ${origin_branch}"
+  else
+    echo "❌ Current commit is missing changes from ${origin_branch}"
+    echo "Run 'git pull origin ${upstream_branch}' to update your branch"
+    return 1
+  fi
+
+  # If requested, also check that we're at the head of our current branch
+  if [[ "${check_current_branch_head}" == "true" ]]; then
+    local current_branch
+    current_branch=$(git branch --show-current 2>/dev/null)
+
+    if [[ -z "${current_branch}" ]]; then
+      echo "❌ Unable to determine current branch (detached HEAD?)"
+      echo "Make sure you're on a named branch, not a detached HEAD"
+      return 1
+    fi
+
+    # Skip branch head check if we're already on the upstream branch
+    # (we've already validated it's up-to-date above)
+    if [[ "${current_branch}" == "${upstream_branch}" ]]; then
+      echo "--- Skipping branch head check (already validated ${current_branch} is up-to-date)"
+    else
+      echo "--- Checking if current commit is the latest on branch '${current_branch}'"
+
+      # Fetch the current branch from origin
+      if ! git fetch origin "${current_branch}" 2>/dev/null; then
+        echo "⚠️ Unable to fetch origin/${current_branch} (branch may not exist on remote)"
+        echo "Skipping current branch head check"
+      else
+        local origin_current_branch="origin/${current_branch}"
+
+        # Check if HEAD matches the remote branch head
+        if git diff --quiet HEAD "${origin_current_branch}"; then
+          echo "✅ Current commit is the latest on ${origin_current_branch}"
+        else
+          echo "❌ Current commit is not the latest on ${origin_current_branch}"
+          echo "Run 'git pull origin ${current_branch}' to get the latest commits"
+          return 1
+        fi
+      fi
+    fi
+  fi
+
+  return 0
+}

--- a/plugin.yml
+++ b/plugin.yml
@@ -24,5 +24,9 @@ configuration:
         must-be-branch-head:
           type: boolean
           default: false
+        fail-mode:
+          type: string
+          enum: ["hard", "soft"]
+          default: "hard"
       additionalProperties: false
   additionalProperties: false

--- a/plugin.yml
+++ b/plugin.yml
@@ -24,9 +24,8 @@ configuration:
         must-be-branch-head:
           type: boolean
           default: false
-        fail-mode:
-          type: string
-          enum: ["hard", "soft"]
-          default: "hard"
+        soft-fail:
+          type: boolean
+          default: false
       additionalProperties: false
   additionalProperties: false

--- a/plugin.yml
+++ b/plugin.yml
@@ -12,4 +12,17 @@ configuration:
       type: array
     selector-template:
       type: string
+    require-up-to-date:
+      type: object
+      properties:
+        enabled:
+          type: boolean
+          default: false
+        branch:
+          type: string
+          default: "main"
+        must-be-branch-head:
+          type: boolean
+          default: false
+      additionalProperties: false
   additionalProperties: false

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -220,12 +220,12 @@ teardown() {
   unstub git
 }
 
-@test "require-up-to-date with soft fail-mode succeeds with warning when validation fails" {
+@test "require-up-to-date with soft-fail succeeds with warning when validation fails" {
   export BUILDKITE_PLUGIN_STEP_TEMPLATES_STEP_TEMPLATE="/tmp/step-template.yaml"
   export BUILDKITE_PLUGIN_STEP_TEMPLATES_AUTO_SELECTIONS_0="auto-one"
   export BUILDKITE_PLUGIN_STEP_TEMPLATES_REQUIRE_UP_TO_DATE_ENABLED="true"
   export BUILDKITE_PLUGIN_STEP_TEMPLATES_REQUIRE_UP_TO_DATE_BRANCH="main"
-  export BUILDKITE_PLUGIN_STEP_TEMPLATES_REQUIRE_UP_TO_DATE_FAIL_MODE="soft"
+  export BUILDKITE_PLUGIN_STEP_TEMPLATES_REQUIRE_UP_TO_DATE_SOFT_FAIL="true"
 
   stub git \
     "fetch origin main : exit 0" \
@@ -240,12 +240,12 @@ teardown() {
   unstub git
 }
 
-@test "require-up-to-date with hard fail-mode fails when validation fails" {
+@test "require-up-to-date with hard fail (explicit) fails when validation fails" {
   export BUILDKITE_PLUGIN_STEP_TEMPLATES_STEP_TEMPLATE="/tmp/step-template.yaml"
   export BUILDKITE_PLUGIN_STEP_TEMPLATES_AUTO_SELECTIONS_0="auto-one"
   export BUILDKITE_PLUGIN_STEP_TEMPLATES_REQUIRE_UP_TO_DATE_ENABLED="true"
   export BUILDKITE_PLUGIN_STEP_TEMPLATES_REQUIRE_UP_TO_DATE_BRANCH="main"
-  export BUILDKITE_PLUGIN_STEP_TEMPLATES_REQUIRE_UP_TO_DATE_FAIL_MODE="hard"
+  export BUILDKITE_PLUGIN_STEP_TEMPLATES_REQUIRE_UP_TO_DATE_SOFT_FAIL="false"
 
   stub git \
     "fetch origin main : exit 0" \
@@ -260,7 +260,7 @@ teardown() {
   unstub git
 }
 
-@test "require-up-to-date uses hard fail-mode by default" {
+@test "require-up-to-date uses hard fail by default" {
   export BUILDKITE_PLUGIN_STEP_TEMPLATES_STEP_TEMPLATE="/tmp/step-template.yaml"
   export BUILDKITE_PLUGIN_STEP_TEMPLATES_AUTO_SELECTIONS_0="auto-one"
   export BUILDKITE_PLUGIN_STEP_TEMPLATES_REQUIRE_UP_TO_DATE_ENABLED="true"

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -96,3 +96,126 @@ teardown() {
   assert_success
   assert_output --partial "STEP_SELECTOR_ID=\"\""
 }
+
+@test "require-up-to-date disabled by default" {
+  export BUILDKITE_PLUGIN_STEP_TEMPLATES_STEP_TEMPLATE="/tmp/step-template.yaml"
+  export BUILDKITE_PLUGIN_STEP_TEMPLATES_AUTO_SELECTIONS_0="auto-one"
+
+  run "$PWD/hooks/command"
+
+  assert_success
+  refute_output --partial "Checking if current branch is up-to-date"
+}
+
+@test "require-up-to-date succeeds when enabled and branch is up-to-date" {
+  export BUILDKITE_PLUGIN_STEP_TEMPLATES_STEP_TEMPLATE="/tmp/step-template.yaml"
+  export BUILDKITE_PLUGIN_STEP_TEMPLATES_AUTO_SELECTIONS_0="auto-one"
+  export BUILDKITE_PLUGIN_STEP_TEMPLATES_REQUIRE_UP_TO_DATE_ENABLED="true"
+  export BUILDKITE_PLUGIN_STEP_TEMPLATES_REQUIRE_UP_TO_DATE_BRANCH="main"
+
+  stub git \
+    "fetch origin main : exit 0" \
+    "merge-base --is-ancestor HEAD origin/main : exit 0"
+
+  run "$PWD/hooks/command"
+
+  assert_success
+  assert_output --partial "✅ Current commit includes all changes from origin/main"
+  unstub git
+}
+
+@test "require-up-to-date fails when enabled and branch is behind" {
+  export BUILDKITE_PLUGIN_STEP_TEMPLATES_STEP_TEMPLATE="/tmp/step-template.yaml"
+  export BUILDKITE_PLUGIN_STEP_TEMPLATES_AUTO_SELECTIONS_0="auto-one"
+  export BUILDKITE_PLUGIN_STEP_TEMPLATES_REQUIRE_UP_TO_DATE_ENABLED="true"
+  export BUILDKITE_PLUGIN_STEP_TEMPLATES_REQUIRE_UP_TO_DATE_BRANCH="main"
+
+  stub git \
+    "fetch origin main : exit 0" \
+    "merge-base --is-ancestor HEAD origin/main : exit 1"
+
+  run "$PWD/hooks/command"
+
+  assert_failure
+  assert_output --partial "❌ Current commit is missing changes from origin/main"
+  assert_output --partial "Branch validation failed"
+  unstub git
+}
+
+@test "require-up-to-date uses default branch when not specified" {
+  export BUILDKITE_PLUGIN_STEP_TEMPLATES_STEP_TEMPLATE="/tmp/step-template.yaml"
+  export BUILDKITE_PLUGIN_STEP_TEMPLATES_AUTO_SELECTIONS_0="auto-one"
+  export BUILDKITE_PLUGIN_STEP_TEMPLATES_REQUIRE_UP_TO_DATE_ENABLED="true"
+
+  stub git \
+    "fetch origin main : exit 0" \
+    "merge-base --is-ancestor HEAD origin/main : exit 0"
+
+  run "$PWD/hooks/command"
+
+  assert_success
+  assert_output --partial "✅ Current commit includes all changes from origin/main"
+  unstub git
+}
+
+@test "require-up-to-date works with custom branch" {
+  export BUILDKITE_PLUGIN_STEP_TEMPLATES_STEP_TEMPLATE="/tmp/step-template.yaml"
+  export BUILDKITE_PLUGIN_STEP_TEMPLATES_AUTO_SELECTIONS_0="auto-one"
+  export BUILDKITE_PLUGIN_STEP_TEMPLATES_REQUIRE_UP_TO_DATE_ENABLED="true"
+  export BUILDKITE_PLUGIN_STEP_TEMPLATES_REQUIRE_UP_TO_DATE_BRANCH="develop"
+
+  stub git \
+    "fetch origin develop : exit 0" \
+    "merge-base --is-ancestor HEAD origin/develop : exit 0"
+
+  run "$PWD/hooks/command"
+
+  assert_success
+  assert_output --partial "✅ Current commit includes all changes from origin/develop"
+  unstub git
+}
+
+@test "require-up-to-date with must-be-branch-head succeeds when both checks pass" {
+  export BUILDKITE_PLUGIN_STEP_TEMPLATES_STEP_TEMPLATE="/tmp/step-template.yaml"
+  export BUILDKITE_PLUGIN_STEP_TEMPLATES_AUTO_SELECTIONS_0="auto-one"
+  export BUILDKITE_PLUGIN_STEP_TEMPLATES_REQUIRE_UP_TO_DATE_ENABLED="true"
+  export BUILDKITE_PLUGIN_STEP_TEMPLATES_REQUIRE_UP_TO_DATE_BRANCH="main"
+  export BUILDKITE_PLUGIN_STEP_TEMPLATES_REQUIRE_UP_TO_DATE_MUST_BE_BRANCH_HEAD="true"
+
+  stub git \
+    "fetch origin main : exit 0" \
+    "merge-base --is-ancestor HEAD origin/main : exit 0" \
+    "branch --show-current : echo feature-branch" \
+    "fetch origin feature-branch : exit 0" \
+    "diff --quiet HEAD origin/feature-branch : exit 0"
+
+  run "$PWD/hooks/command"
+
+  assert_success
+  assert_output --partial "✅ Current commit includes all changes from origin/main"
+  assert_output --partial "✅ Current commit is the latest on origin/feature-branch"
+  unstub git
+}
+
+@test "require-up-to-date with must-be-branch-head fails when current branch is behind" {
+  export BUILDKITE_PLUGIN_STEP_TEMPLATES_STEP_TEMPLATE="/tmp/step-template.yaml"
+  export BUILDKITE_PLUGIN_STEP_TEMPLATES_AUTO_SELECTIONS_0="auto-one"
+  export BUILDKITE_PLUGIN_STEP_TEMPLATES_REQUIRE_UP_TO_DATE_ENABLED="true"
+  export BUILDKITE_PLUGIN_STEP_TEMPLATES_REQUIRE_UP_TO_DATE_BRANCH="main"
+  export BUILDKITE_PLUGIN_STEP_TEMPLATES_REQUIRE_UP_TO_DATE_MUST_BE_BRANCH_HEAD="true"
+
+  stub git \
+    "fetch origin main : exit 0" \
+    "merge-base --is-ancestor HEAD origin/main : exit 0" \
+    "branch --show-current : echo feature-branch" \
+    "fetch origin feature-branch : exit 0" \
+    "diff --quiet HEAD origin/feature-branch : exit 1"
+
+  run "$PWD/hooks/command"
+
+  assert_failure
+  assert_output --partial "✅ Current commit includes all changes from origin/main"
+  assert_output --partial "❌ Current commit is not the latest on origin/feature-branch"
+  assert_output --partial "Branch validation failed: branch requirements not met"
+  unstub git
+}

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -219,3 +219,62 @@ teardown() {
   assert_output --partial "Branch validation failed: branch requirements not met"
   unstub git
 }
+
+@test "require-up-to-date with soft fail-mode succeeds with warning when validation fails" {
+  export BUILDKITE_PLUGIN_STEP_TEMPLATES_STEP_TEMPLATE="/tmp/step-template.yaml"
+  export BUILDKITE_PLUGIN_STEP_TEMPLATES_AUTO_SELECTIONS_0="auto-one"
+  export BUILDKITE_PLUGIN_STEP_TEMPLATES_REQUIRE_UP_TO_DATE_ENABLED="true"
+  export BUILDKITE_PLUGIN_STEP_TEMPLATES_REQUIRE_UP_TO_DATE_BRANCH="main"
+  export BUILDKITE_PLUGIN_STEP_TEMPLATES_REQUIRE_UP_TO_DATE_FAIL_MODE="soft"
+
+  stub git \
+    "fetch origin main : exit 0" \
+    "merge-base --is-ancestor HEAD origin/main : exit 1"
+
+  run "$PWD/hooks/command"
+
+  assert_success
+  assert_output --partial "❌ Current commit is missing changes from origin/main"
+  assert_output --partial "+++ ⚠️ Step templates plugin warning"
+  assert_output --partial "soft-fail mode: continuing without uploading steps"
+  unstub git
+}
+
+@test "require-up-to-date with hard fail-mode fails when validation fails" {
+  export BUILDKITE_PLUGIN_STEP_TEMPLATES_STEP_TEMPLATE="/tmp/step-template.yaml"
+  export BUILDKITE_PLUGIN_STEP_TEMPLATES_AUTO_SELECTIONS_0="auto-one"
+  export BUILDKITE_PLUGIN_STEP_TEMPLATES_REQUIRE_UP_TO_DATE_ENABLED="true"
+  export BUILDKITE_PLUGIN_STEP_TEMPLATES_REQUIRE_UP_TO_DATE_BRANCH="main"
+  export BUILDKITE_PLUGIN_STEP_TEMPLATES_REQUIRE_UP_TO_DATE_FAIL_MODE="hard"
+
+  stub git \
+    "fetch origin main : exit 0" \
+    "merge-base --is-ancestor HEAD origin/main : exit 1"
+
+  run "$PWD/hooks/command"
+
+  assert_failure
+  assert_output --partial "❌ Current commit is missing changes from origin/main"
+  assert_output --partial "+++ ❌ Step templates plugin error"
+  assert_output --partial "Branch validation failed: branch requirements not met"
+  unstub git
+}
+
+@test "require-up-to-date uses hard fail-mode by default" {
+  export BUILDKITE_PLUGIN_STEP_TEMPLATES_STEP_TEMPLATE="/tmp/step-template.yaml"
+  export BUILDKITE_PLUGIN_STEP_TEMPLATES_AUTO_SELECTIONS_0="auto-one"
+  export BUILDKITE_PLUGIN_STEP_TEMPLATES_REQUIRE_UP_TO_DATE_ENABLED="true"
+  export BUILDKITE_PLUGIN_STEP_TEMPLATES_REQUIRE_UP_TO_DATE_BRANCH="main"
+
+  stub git \
+    "fetch origin main : exit 0" \
+    "merge-base --is-ancestor HEAD origin/main : exit 1"
+
+  run "$PWD/hooks/command"
+
+  assert_failure
+  assert_output --partial "❌ Current commit is missing changes from origin/main"
+  assert_output --partial "+++ ❌ Step templates plugin error"
+  assert_output --partial "Branch validation failed: branch requirements not met"
+  unstub git
+}

--- a/tests/shared.bats
+++ b/tests/shared.bats
@@ -55,3 +55,142 @@ function create_template_file() {
 
   assert_equal "${key}" "first-key"
 }
+
+@test "validate_branch_up_to_date succeeds when branch is up-to-date" {
+  stub git \
+    "fetch origin main : exit 0" \
+    "merge-base --is-ancestor HEAD origin/main : exit 0"
+
+  run validate_branch_up_to_date "main"
+
+  assert_success
+  assert_output --partial "✅ Current commit includes all changes from origin/main"
+  unstub git
+}
+
+@test "validate_branch_up_to_date fails when branch is behind" {
+  stub git \
+    "fetch origin main : exit 0" \
+    "merge-base --is-ancestor HEAD origin/main : exit 1"
+
+  run validate_branch_up_to_date "main"
+
+  assert_failure
+  assert_output --partial "❌ Current commit is missing changes from origin/main"
+  assert_output --partial "Run 'git pull origin main' to update your branch"
+  unstub git
+}
+
+@test "validate_branch_up_to_date fails when fetch fails" {
+  stub git \
+    "fetch origin main : exit 1"
+
+  run validate_branch_up_to_date "main"
+
+  assert_failure
+  assert_output --partial "❌ Failed to fetch from origin/main"
+  assert_output --partial "Make sure the branch 'main' exists on origin"
+  unstub git
+}
+
+@test "validate_branch_up_to_date uses default branch when none specified" {
+  stub git \
+    "fetch origin main : exit 0" \
+    "merge-base --is-ancestor HEAD origin/main : exit 0"
+
+  run validate_branch_up_to_date
+
+  assert_success
+  assert_output --partial "✅ Current commit includes all changes from origin/main"
+  unstub git
+}
+
+@test "validate_branch_up_to_date works with custom branch" {
+  stub git \
+    "fetch origin develop : exit 0" \
+    "merge-base --is-ancestor HEAD origin/develop : exit 0"
+
+  run validate_branch_up_to_date "develop"
+
+  assert_success
+  assert_output --partial "✅ Current commit includes all changes from origin/develop"
+  unstub git
+}
+
+@test "validate_branch_up_to_date with must-be-branch-head succeeds when both checks pass" {
+  stub git \
+    "fetch origin main : exit 0" \
+    "merge-base --is-ancestor HEAD origin/main : exit 0" \
+    "branch --show-current : echo feature-branch" \
+    "fetch origin feature-branch : exit 0" \
+    "diff --quiet HEAD origin/feature-branch : exit 0"
+
+  run validate_branch_up_to_date "main" "true"
+
+  assert_success
+  assert_output --partial "✅ Current commit includes all changes from origin/main"
+  assert_output --partial "✅ Current commit is the latest on origin/feature-branch"
+  unstub git
+}
+
+@test "validate_branch_up_to_date with must-be-branch-head fails when current branch is behind" {
+  stub git \
+    "fetch origin main : exit 0" \
+    "merge-base --is-ancestor HEAD origin/main : exit 0" \
+    "branch --show-current : echo feature-branch" \
+    "fetch origin feature-branch : exit 0" \
+    "diff --quiet HEAD origin/feature-branch : exit 1"
+
+  run validate_branch_up_to_date "main" "true"
+
+  assert_failure
+  assert_output --partial "✅ Current commit includes all changes from origin/main"
+  assert_output --partial "❌ Current commit is not the latest on origin/feature-branch"
+  assert_output --partial "Run 'git pull origin feature-branch' to get the latest commits"
+  unstub git
+}
+
+@test "validate_branch_up_to_date with must-be-branch-head handles detached HEAD" {
+  stub git \
+    "fetch origin main : exit 0" \
+    "merge-base --is-ancestor HEAD origin/main : exit 0" \
+    "branch --show-current : echo"
+
+  run validate_branch_up_to_date "main" "true"
+
+  assert_failure
+  assert_output --partial "✅ Current commit includes all changes from origin/main"
+  assert_output --partial "❌ Unable to determine current branch (detached HEAD?)"
+  assert_output --partial "Make sure you're on a named branch, not a detached HEAD"
+  unstub git
+}
+
+@test "validate_branch_up_to_date with must-be-branch-head handles missing remote branch" {
+  stub git \
+    "fetch origin main : exit 0" \
+    "merge-base --is-ancestor HEAD origin/main : exit 0" \
+    "branch --show-current : echo feature-branch" \
+    "fetch origin feature-branch : exit 1"
+
+  run validate_branch_up_to_date "main" "true"
+
+  assert_success
+  assert_output --partial "✅ Current commit includes all changes from origin/main"
+  assert_output --partial "⚠️ Unable to fetch origin/feature-branch (branch may not exist on remote)"
+  assert_output --partial "Skipping current branch head check"
+  unstub git
+}
+
+@test "validate_branch_up_to_date with must-be-branch-head skips check when on upstream branch" {
+  stub git \
+    "fetch origin main : exit 0" \
+    "merge-base --is-ancestor HEAD origin/main : exit 0" \
+    "branch --show-current : echo main"
+
+  run validate_branch_up_to_date "main" "true"
+
+  assert_success
+  assert_output --partial "✅ Current commit includes all changes from origin/main"
+  assert_output --partial "--- Skipping branch head check (already validated main is up-to-date)"
+  unstub git
+}


### PR DESCRIPTION
## Summary

Adds a new `require-up-to-date` configuration option to validate commit _freshness_ before step generation. This prevents deployments from stale commits — a critical safeguard for infrastructure deployments (e.g., Terraform) where missing changes could cause accidental resource deletion, while still allowing for the main functionality of step templates to be used while up to date. 

This replaces the need for custom commit validation scripts, such as [this one in kafka-ops](https://github.com/search?q=repo%3Acultureamp%2Fkafka-ops%20.buildkite%2Fscripts%2Fcommon%2Fci_commit_check.sh&type=code). I was about to implement a similar setup in `clickhouse-ops` before realising it should be part of this plugin.

## Key Features

- **`enabled`** (`boolean`, default: `false`) – Toggle commit validation on/off.  
- **`branch`** (`string`, default: `"main"`) – Upstream branch to validate against.  
- **`must-be-branch-head`** (`boolean`, default: `false`) – Require the commit to be the latest on the current branch.  
- **`soft-fail`** (`boolean`, default: `false`) – Allow validation failures without failing the build. When `true`, validation failures will skip uploading steps but won't fail the build. (This stops people triggering old builds polluting build failure alerts)

## How It Works

- Uses `git merge-base --is-ancestor` to confirm the current commit includes all changes from `origin/<branch>`.  
- When `must-be-branch-head` is enabled, also validates the commit is the latest on the current branch.  
- Includes optimisations to skip redundant checks when already on the upstream branch.  

## Example Configuration

```yaml
steps:
  - plugins:
      - cultureamp/step-templates#main:
          step-template: terraform-deploy-steps.yml
          require-up-to-date:
            enabled: true
            branch: "main"
            must-be-branch-head: true
```

## Replaces Custom Scripts / Steps

This standardized approach can replace custom commit validation scripts and 

Benefits of using the plugin instead:
- ✅ Standardized across all repositories using step-templates
- ✅ Comprehensive test coverage and edge case handling
- ✅ Smart optimizations (avoids redundant checks)
- ✅ Clear error messages with remediation steps
- ✅ No need to maintain custom scripts

## Test plan

- [x] All existing tests continue to pass (36/36)
- [x] New unit tests for validation function (5 test cases)
- [x] New integration tests for command hook (7 test cases)  
- [x] Edge cases covered (detached HEAD, missing remote branches, etc.)
- [x] Smart optimization tested (skips redundant checks)