### PR TITLE
chore(catalog): add asset-criticality tags per new standard

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -7,8 +7,8 @@ metadata:
   tags:
     - buildkite-plugin
     - camp-sre
-    - data-internal-use-only
-    - users-internal
+    - data-classification-internal-use-only
+    - asset-criticality-high
   annotations:
     github.com/project-slug: cultureamp/step-templates-buildkite-plugin
     github.com/team-slug: cultureamp/sre-enablement


### PR DESCRIPTION
## Summary

- Replaces legacy `data-internal-use-only` tag with `data-classification-internal-use-only`
- Removes non-standard `users-internal` tag
- Adds missing `asset-criticality-high` tag required by the [Backstage catalog-info standard](https://cultureamp.atlassian.net/wiki/spaces/TV/pages/6297977076) published Jun 22 2026

## Test plan

- [ ] Backstage catalog refreshes and component appears with correct tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)